### PR TITLE
Handle repo check failures without exiting

### DIFF
--- a/docker/build_package.sh
+++ b/docker/build_package.sh
@@ -22,7 +22,11 @@ fn_install_dependencies() {
     for item in $package_list; do
         item="${item//<}"
         item="${item//>}"
-        pacman -Si $item > /dev/null && repo_package_list+=" $item" || aur_package_list+=" $item"
+        if pacman -Si "$item" >/dev/null 2>&1; then
+            repo_package_list+=" $item"
+        else
+            aur_package_list+=" $item"
+        fi
     done
     sudo pacman -Syu --noconfirm $repo_package_list
     for item in $aur_package_list; do


### PR DESCRIPTION
## Summary
- Prevent `pacman -Si` failures from exiting script prematurely
- Sort dependencies into repo/AUR lists with explicit conditional check

## Testing
- `bash -n docker/build_package.sh`
- `shellcheck docker/build_package.sh` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689eec6b5598832cb76f855e5a34f1d5