### PR TITLE
Drop version constraints when resolving dependencies

### DIFF
--- a/docker/build_package.sh
+++ b/docker/build_package.sh
@@ -20,8 +20,7 @@ fn_install_dependencies() {
     local aur_package_list
     aur_package_list=""
     for item in $package_list; do
-        item="${item//<}"
-        item="${item//>}"
+        item="${item%%[<>=]*}"
         pacman -Si $item > /dev/null && repo_package_list+=" $item" || aur_package_list+=" $item"
     done
     sudo pacman -Syu --noconfirm $repo_package_list


### PR DESCRIPTION
## Summary
- Simplify dependency parsing to remove version comparisons before repository lookup

## Testing
- `bash -n docker/build_package.sh`
- `bash check_pkgbuilds.sh` *(fails: podman: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eec613af4832cbd56b4c167f309c5