### PR TITLE
feat: refresh pacman database before installing dependencies

### DIFF
--- a/docker/build_package.sh
+++ b/docker/build_package.sh
@@ -24,7 +24,9 @@ fn_install_dependencies() {
         item="${item//>}"
         pacman -Si $item > /dev/null && repo_package_list+=" $item" || aur_package_list+=" $item"
     done
-    sudo pacman -Syu --noconfirm $repo_package_list
+    if [[ -n "$repo_package_list" ]]; then
+        sudo pacman -Sy --noconfirm --needed $repo_package_list
+    fi
     for item in $aur_package_list; do
         fn_install_aur_package "$item"
     done


### PR DESCRIPTION
## Summary
- refresh package databases before installing repo packages

## Testing
- `bash -n docker/build_package.sh`
- `bash check_pkgbuilds.sh` *(fails: podman command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eec6cebb0832cb85901c17bad0591