### PR TITLE
Pin pacman mirror for Arch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker.io/library/archlinux:base-devel
 
+# Use a fixed Arch Linux mirror to ensure reproducible builds
+RUN echo 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+
 RUN echo "ALL ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
 RUN useradd --create-home user
 


### PR DESCRIPTION
## Summary
- ensure Dockerfile always uses the Rackspace Arch Linux mirror for reproducible builds

## Testing
- `bash ./check_pkgbuilds.sh` *(fails: podman: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ee8fffc90832cb309e7f01ed6901c