### PR TITLE
Disable Docker cache for builder workflow

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -11,8 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Build and publish a Docker image for ${{ github.repository }}
-        uses: macbre/push-to-ghcr@master
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
         with:
-          image_name: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          pull: true
+          no-cache: true


### PR DESCRIPTION
## Summary
- build Docker image without cache using docker/build-push-action

## Testing
- `yamllint .github/workflows/build_container.yml` *(command not found)*
- `pip install --user yamllint` *(ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1b1cc8c832c99725126fe42d6a2