### PR TITLE
Schedule weekly repository builds and conditionally draft releases

### DIFF
--- a/.github/workflows/build_repository.yml
+++ b/.github/workflows/build_repository.yml
@@ -1,5 +1,7 @@
 run-name: Build repository ${{ inputs.repository_name }} with list ${{ inputs.package_list }}.
 on:
+  schedule:
+    - cron: "0 8 * * 6"
   workflow_dispatch:
     inputs:
       package_list:
@@ -50,4 +52,4 @@ jobs:
           tag_name: ${{ github.sha }}
           release_name: ${{ github.sha }}
           asset_files: ./package_files
-          draft: true
+          draft: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
## Summary
- run repository build every Saturday at 08:00 UTC
- always create draft releases for manually dispatched runs while scheduled runs publish final releases

## Testing
- `actionlint -version` *(command not found)*
- `curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.sh | sh` *(403 Forbidden)*
- `go install github.com/rhysd/actionlint/cmd/actionlint@latest` *(Forbidden)*
- `apt-get update` *(403 Forbidden)*
- `actionlint .github/workflows/build_repository.yml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689efa27ff1c832c9880e9eb12ddb1bc