### PR TITLE
Add workflow to trigger update PRs for all packages

### DIFF
--- a/.github/workflows/run_update_prs.yml
+++ b/.github/workflows/run_update_prs.yml
@@ -1,0 +1,22 @@
+name: Run update PRs for all packages
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * *"
+
+permissions: write-all
+
+jobs:
+  update-all:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trigger update workflow for each package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for dir in packages/*; do
+            pkg="$(basename "$dir")"
+            gh workflow run create_package_update_pr.yml -F package_name="$pkg"
+          done


### PR DESCRIPTION
## Summary
- add workflow to trigger package update PR generator across all packages on a schedule or manual run
- run update workflow daily at 10:00 UTC

## Testing
- `wget https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash -O - | bash` *(fails: Proxy tunneling failed: ForbiddenUnable to establish SSL connection.)*


------
https://chatgpt.com/codex/tasks/task_e_68a013373820832c935165dd920a6a55